### PR TITLE
Modified dockerfile to build on other archs as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine as builder
 WORKDIR /build
 ADD . /build/
 
-RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 go build -mod=vendor -o api-server .
+RUN export GARCH="$(uname -m)" && if [[ ${GARCH} == "x86_64" ]]; then export GARCH="amd64"; fi && GOOS=linux GOARCH=${GARCH} CGO_ENABLED=0 go build -mod=vendor -o api-server .
 
 FROM scratch
 


### PR DESCRIPTION
Hi All,

This repository is used in pipelines-tutorials and hence while executing e2e tests they fail on Ppc64le and s390x.  We have updated dockerfile to build it on other architectures than x86. Please review.  

Thanks,
Snehlata Mohite. 